### PR TITLE
Issue#20 Duplicate username and email for registration

### DIFF
--- a/InLectureECommerceWebsite/Controllers/MemberController.cs
+++ b/InLectureECommerceWebsite/Controllers/MemberController.cs
@@ -72,11 +72,11 @@ public class MemberController : Controller
     {
         if (ModelState.IsValid)
         {
-            Member? loggedInMember = await _context.Members
-                                .Where(m => (m.Username == login.UsernameOrEmail || m.Email == login.UsernameOrEmail)
-                                    && m.password == login.Password)
-                                .SingleOrDefaultAsync();
-
+            var loggedInMember = await _context.Members
+                                    .Where(m => (m.Username == login.UsernameOrEmail || m.Email == login.UsernameOrEmail)
+                                        && m.password == login.Password)
+                                    .Select(m => new { m.Username, m.MemberId })
+                                    .SingleOrDefaultAsync();
             if (loggedInMember == null)
             {
                 ModelState.AddModelError(string.Empty, "Your provided credentials do not match any records in our database.");


### PR DESCRIPTION
Closes #20

This pull request makes a small but important change to the login logic in `MemberController.cs`. The query now only selects the necessary fields (`Username` and `MemberId`) when checking user credentials, instead of retrieving the entire `Member` entity. This helps improve both performance and security by limiting the amount of user data loaded during login.